### PR TITLE
fix: fix empty/wrong DML parameters required for AWLAN_Node

### DIFF
--- a/src/lib/osp/src/osp_unit_rdk.c
+++ b/src/lib/osp/src/osp_unit_rdk.c
@@ -128,12 +128,25 @@ bool osp_unit_sku_get(char *buff, size_t buffsz)
 
 bool osp_unit_model_get(char *buff, size_t buffsz)
 {
+    int old_char = ' ';
+    int new_char = '_';
+    char *char_ptr = NULL;
+
     if (!osp_unit_cache.model_cached)
     {
         if (!dmcli_eRT_getv(DMCLI_ERT_MODEL_NUM,
                           ARRAY_AND_SIZE(osp_unit_cache.model), false))
         {
             return false;
+        }
+        char_ptr = strchr(osp_unit_cache.model, old_char);
+        if (char_ptr != NULL)
+        {
+            *char_ptr = new_char;
+        }
+        else
+        {
+            LOG(ERR, "Unable to parse model %s", osp_unit_cache.model);
         }
         osp_unit_cache.model_cached = true;
     }


### PR DESCRIPTION
In order to fix the issue with OpenSync connectivity to the cloud, we need to adjust DML values. Currently returned values are:
   Device.DeviceInfo.ModelName  - Cougar Run
   Device.DeviceInfo.X_RDKCENTRAL-COM_CMTS_MAC - 00:00:00:00:00:00

Instead, the values should be:
   Device.DeviceInfo.ModelName - PUMA7_CGR
   Device.DeviceInfo.X_RDKCENTRAL-COM_CMTS_MAC - should return CM WAN MAC address

These values should be adjusted for OpenSync flavors, but if it is a generic issue, it can be extended to non-OpenSync flavors also.